### PR TITLE
Refactor Presto Usage Data Route to Handle Multiple Cards

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3334,8 +3334,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3353,13 +3352,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3372,18 +3369,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3486,8 +3480,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3497,7 +3490,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3510,20 +3502,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3540,7 +3529,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3613,8 +3601,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3624,7 +3611,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3700,8 +3686,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3731,7 +3716,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3749,7 +3733,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3788,13 +3771,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -24,7 +24,7 @@ const Budget = require('./db/models/budget')(sequelize, Sequelize, User);
 
 // routes
 const userRoutes = require('./routes/users')(User, Budget, Transaction, sequelize, Sequelize);
-const prestoRoutes = require('./routes/presto')(Transaction, User);
+const prestoRoutes = require('./routes/presto')(Transaction, User, sequelize, Sequelize);
 const transactionRoutes = require('./routes/transactions')(Transaction, sequelize, Sequelize);
 const budgetRoutes = require('./routes/budget')(Budget, sequelize, Sequelize);
 

--- a/server/src/routes/presto.js
+++ b/server/src/routes/presto.js
@@ -88,13 +88,16 @@ const routes = (Transaction, User, sequelize, Sequelize) => {
       group: ['cardNumber']
     });
 
-    console.log(eachCardLastTransaction);
-
     // convert the dates using moment
     // and create an array with the essential pieces necessary for the next query?
     // Wondering how necessary it is to loop through everything here
     // instead of just working with the eachCardLastTransaction object directly.
-    const lastTransactionDates = eachCardLastTransaction.map(row => ({
+    //
+    // For some reason the [sequelize.fn('MAX', ...), 'lastTransactionDate'], above with the lastTransactionDate alias
+    // is returning undefined when trying to access the lastTransactionDate attribute. This
+    // super hacky JSON.parse(JSON.stringify()) seems to fix the issue. I'll look into how to actually
+    // fix this later.
+    const lastTransactionDates = JSON.parse(JSON.stringify(eachCardLastTransaction)).map(row => ({
       cardNumber: row.cardNumber,
       lastTransactionDate: row.lastTransactionDate
         ? moment(row.lastTransactionDate).format('MM/DD/YYYY')
@@ -103,50 +106,61 @@ const routes = (Transaction, User, sequelize, Sequelize) => {
       toDate: to ? moment(to).format('MM/DD/YYYY') : moment().format('MM/DD/YYYY')
     }));
 
-    console.log('lastTransactionDates:', lastTransactionDates);
+    console.log('lastTransactionDates with time formatting:', JSON.stringify(lastTransactionDates));
 
-    const resolvedActivityArray = await Promise.all(
-      lastTransactionDates.map(async card => {
-        const usage = await getActivityByDateRange(
-          card.lastTransactionDate,
-          card.toDate,
-          card.cardNumber
-        );
-
-        // if (usage.status === 'error') {
-        //   throw new Error(usage.message);
-        // }
-
-        return usage;
-      })
+    const promiseArray = lastTransactionDates.map(card => () =>
+      getActivityByDateRange(card.lastTransactionDate, card.toDate, card.cardNumber)
     );
 
-    console.log(resolvedActivityArray);
+    // I cannot figure out any better way to run these promises serially.
+    // They have to be run serially because the correct data being returned
+    // depends on the state of the DOM set by the setCard() function in the
+    // the Presto API util. If the promises are run in parallel, getActivityByDateRange()
+    // ends up performing all card transaction lookups on the same set of Data (the last DOM state set by setCard).
+    const resolvedActivityObject = {};
 
-    // get activity from db
+    for (let i = 0; i < promiseArray.length; i += 1) {
+      Object.assign(resolvedActivityObject, await promiseArray[i]());
+    }
+
+    console.log('resolvedActivityObject:', JSON.stringify(resolvedActivityObject));
+
+    let filteredActivity = [];
+
+    lastTransactionDates.forEach(card => {
+      filteredActivity = resolvedActivityObject[card.cardNumber].filter(item => {
+        console.log(moment(item.date).format('MM/DD/YYYY hh:mm:ss A') > card.filterDateString);
+        console.log(moment(item.date).format('MM/DD/YYYY hh:mm:ss A'));
+        console.log(card.filterDateString);
+        return moment(item.date).format('MM/DD/YYYY hh:mm:ss A') > card.filterDateString;
+      });
+    });
+
+    console.log('filteredActivity:', filteredActivity);
 
     // worst case scenerio the lastTransactionDates array is an array of essentially empty objects
     // so this check won't work.
-    if (lastTransactionDates.length > 0) {
-      const resolvedPreviousDataArray = await Promise.all(
-        lastTransactionDates.map(async card => {
-          const possibleDuplicateTransactions = await Transaction.findAll({
-            where: {
-              date: moment(card.lastTransactiondate).format('MM/DD/YYY'),
-              cardNumber: card.cardNumber,
-              userId: req.userId
-            },
-            attributes: ['date']
-          });
+    // if (lastTransactionDates.length > 0) {
+    //   // this path: there are last transaction date so check for dups
+    //   const resolvedPreviousDataArray = await Promise.all(
+    //     lastTransactionDates.map(async card => {
+    //       const possibleDuplicateTransactions = await Transaction.findAll({
+    //         where: {
+    //           date: moment(card.lastTransactionDate).format('MM/DD/YYY'),
+    //           cardNumber: card.cardNumber,
+    //           userId: req.userId
+    //         },
+    //         attributes: ['date']
+    //       });
 
-          return { cardNumber: card.cardNumber, possibleDuplicateTransactions };
-        })
-      );
+    //       return { cardNumber: card.cardNumber, possibleDuplicateTransactions };
+    //     })
+    //   );
 
-      console.log(resolvedPreviousDataArray);
-    } else {
-      console.log('Oh hello!');
-    }
+    //   console.log(resolvedPreviousDataArray);
+    // } else {
+    //   // this path: no last transactions; write everything to the db
+    // }
 
     // // res.json({ status: 'success', usage: filteredUsage });
     // if (lastTransactionDate) {

--- a/server/src/routes/presto.js
+++ b/server/src/routes/presto.js
@@ -1,9 +1,14 @@
 const express = require('express');
 const moment = require('moment');
 
-const { login, getBasicAccountInfo, isLoggedIn, getActivityByDateRange } = require('../../lib/presto');
+const {
+  login,
+  getBasicAccountInfo,
+  isLoggedIn,
+  getActivityByDateRange
+} = require('../../lib/presto');
 
-const routes = (Transaction, User) => {
+const routes = (Transaction, User, sequelize, Sequelize) => {
   const router = express.Router();
 
   router.post('/login', async (req, res) => {
@@ -55,78 +60,99 @@ const routes = (Transaction, User) => {
   });
 
   router.post('/usage', async (req, res, next) => {
-    try {
-      let { from, to, cards } = req.body;
-      let filterDateString = '';
-      let transactions = [];
-      const filteredUsage = [];
+    // try {
+    const { from, to } = req.body;
+    const filterDateString = '';
+    const transactions = [];
 
-      if (!req.userId) {
-        throw new Error('No user logged in!');
-      }
+    const filteredUsage = [];
+    const cards = req.body.cards.split(',') || [];
 
-      for (let i = 0; i < cards.length; i++) {
-        const cardNumber = cards[i];
-
-        console.log('Getting from card number: ', cardNumber);
-        const lastTransactionDate = await Transaction.max('date', {
-          where: {
-            userId: req.userId,
-            cardNumber
-          }
-        });
-
-        if (lastTransactionDate) {
-          from = moment(lastTransactionDate).format('MM/DD/YYYY');
-          filterDateString = moment(lastTransactionDate).format('MM/DD/YYYY hh:mm:ss A');
-        }
-
-        console.log('lastTransactionDate:', !!lastTransactionDate, filterDateString);
-
-        if (!to) {
-          to = moment().format('MM/DD/YYYY');
-        }
-
-        const usage = await getActivityByDateRange(from, to, cardNumber);
-        console.log(usage);
-        if (usage.status === 'error') {
-          throw new Error(usage.message);
-        }
-        console.log('Checking for duplicates...');
-
-        console.log(`Saving usage to db...`);
-
-        // res.json({ status: 'success', usage: filteredUsage });
-        if (lastTransactionDate) {
-          usage.transactions.forEach(async item => {
-            const transactionDate = await Transaction.findOne({
-              where: {
-                date: moment(item.date, 'MM/DD/YYYY hh:mm:ss A'),
-                cardNumber,
-                userId: req.userId
-              },
-              attributes: ['date']
-            });
-
-            if (!transactionDate) {
-              console.log('Not dupe:', item);
-              item.userId = req.userId;
-              transactions = Transaction.create(item);
-            }
-          });
-        } else {
-          const updatedUsage = usage.transactions.map(item => {
-            item.userId = req.userId;
-            return item;
-          });
-          transactions = await Transaction.bulkCreate(updatedUsage);
-        }
-      }
-
-      res.json({ status: 'success', data: transactions });
-    } catch (error) {
-      next(error);
+    if (!req.userId) {
+      throw new Error('No user logged in!');
     }
+
+    console.log('Getting from card number(s): ', cards);
+
+    const eachCardLastTransaction = await Transaction.findAll({
+      attributes: [
+        'cardNumber',
+        [sequelize.fn('MAX', sequelize.col('date')), 'lastTransactionDate']
+      ],
+      where: {
+        userId: req.userId,
+        cardNumber: {
+          [Sequelize.Op.in]: cards
+        }
+      },
+      group: ['cardNumber']
+    });
+
+    // convert the dates using moment
+    // and create an array with the essential pieces necessary for the next query?
+    // Wondering how necessary it is to loop through everything here
+    // instead of just working with the eachCardLastTransaction object directly.
+    const lastTransactionDates = eachCardLastTransaction.map(row => ({
+      cardNumber: row.cardNumber,
+      lastTransactionDate: moment(row.lastTransactionDate).format('MM/DD/YYYY'),
+      filterDateString: moment(row.lastTransactionDate).format('MM/DD/YYYY hh:mm:ss A')
+    }));
+
+    console.log('lastTransactionDates:', lastTransactionDates);
+
+    // if (lastTransactionDate) {
+    //   from = moment(lastTransactionDate).format('MM/DD/YYYY');
+    //   filterDateString = moment(lastTransactionDate).format('MM/DD/YYYY hh:mm:ss A');
+    // }
+
+    // console.log('lastTransactionDate:', !!lastTransactionDate, filterDateString);
+
+    // if (!to) {
+    //   to = moment().format('MM/DD/YYYY');
+    // }
+
+    // // need to fix this to work with arrays
+    const usage = await getActivityByDateRange(from, to, cards);
+    // console.log(usage);
+    // if (usage.status === 'error') {
+    //   throw new Error(usage.message);
+    // }
+    // console.log('Checking for duplicates...');
+
+    // console.log(`Saving usage to db...`);
+
+    // // res.json({ status: 'success', usage: filteredUsage });
+    // if (lastTransactionDate) {
+    //   usage.transactions.forEach(async item => {
+    //     const transactionDate = await Transaction.findOne({
+    //       where: {
+    //         date: moment(item.date, 'MM/DD/YYYY hh:mm:ss A'),
+    //         cardNumber: {
+    //           [Sequelize.Op.in]: cards
+    //         },
+    //         userId: req.userId
+    //       },
+    //       attributes: ['date']
+    //     });
+
+    //     if (!transactionDate) {
+    //       console.log('Not dupe:', item);
+    //       item.userId = req.userId;
+    //       transactions = Transaction.create(item);
+    //     }
+    //   });
+    // } else {
+    //   const updatedUsage = usage.transactions.map(item => {
+    //     item.userId = req.userId;
+    //     return item;
+    //   });
+    //   transactions = await Transaction.bulkCreate(updatedUsage);
+    // }
+
+    // res.json({ status: 'success', data: transactions });
+    // } catch (error) {
+    //   next(error);
+    // }
   });
 
   return router;


### PR DESCRIPTION
Usage data route was pretty inefficient in terms of how it handled multiple cards, but also was pretty tightly coupled to the initial account creation presto data dump. Need to refactor in order for it to work better with subsequent updates of presto data from an already-existing account.