### PR TITLE
Refactored Presto Library into Object in order to make the user's cookie jar specific to the instance created for the user at runtime

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3334,8 +3334,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3353,13 +3352,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3372,18 +3369,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3486,8 +3480,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3497,7 +3490,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3510,20 +3502,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3540,7 +3529,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3613,8 +3601,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3624,7 +3611,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3700,8 +3686,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3731,7 +3716,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3749,7 +3733,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3788,13 +3771,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/server/lib/presto/activity.js
+++ b/server/lib/presto/activity.js
@@ -14,7 +14,7 @@ function removeDuplicates(myArr, prop) {
   );
 }
 
-function getCardsAndBalances(serverResponse) {
+const getCardsAndBalances = serverResponse => {
   const dom = new JSDOM(serverResponse.body);
   const scrapeCards = dom.window.document.querySelectorAll('a.fareMediaID');
   let cards = [];
@@ -34,15 +34,15 @@ function getCardsAndBalances(serverResponse) {
   });
 
   return cards;
-}
+};
 
-async function getBasicAccountInfo(requestInstance, jar) {
-  const cj = jar || requestInstance.jar();
-  const accountResponse = await requestInstance({ uri: API.dashboard, jar: cj });
+const getBasicAccountInfo = async requestInstance => {
+  console.log('Why undefined?', this.cookieJar);
+  const accountResponse = await requestInstance({ uri: API.dashboard, jar: this.cookieJar });
   const cardsAndBalances = getCardsAndBalances(accountResponse);
 
   return cardsAndBalances;
-}
+};
 
 function parseActivity(serverResponse, cardNumber) {
   const dom = new JSDOM(serverResponse.body);
@@ -243,7 +243,7 @@ async function getUsageReport(requestInstance, year) {
         currentModel: ''
       },
       headers: {
-        __RequestVerificationToken: token,
+        __RequestVerificationToken: token.token,
         'Accept-Language': 'en-US,en;q=0.5',
         'Content-Type': 'application/json; charset=utf-8',
         Referrer: 'https://www.prestocard.ca/en/dashboard/card-activity',

--- a/server/lib/presto/activity.js
+++ b/server/lib/presto/activity.js
@@ -98,12 +98,11 @@ function getActivityRequestBody(selectedMonth) {
 async function setCard(requestInstance, cardNumber, jar) {
   try {
     const cj = jar;
-    console.log('setCard jar:', cj);
     const token = await getCSRF(
       requestInstance,
       cj,
       API.dashboard,
-      `form[action='${API.switchCards}']`
+      `form[action='/${API.switchCards}']`
     );
     console.log('Token:', token);
     const response = await requestInstance({
@@ -112,7 +111,7 @@ async function setCard(requestInstance, cardNumber, jar) {
       method: 'POST',
       form: {
         setFareMediaSession: cardNumber,
-        __RequestVerificationToken: token
+        __RequestVerificationToken: token.token
       },
       withCredentials: true,
       followAllRedirects: true
@@ -204,7 +203,7 @@ async function getActivityByDateRange(
       console.log('cookie:', cookie);
       cj.setCookie(cookie.toString(), `${API.baseUrl}`);
     });
-    console.log(cj);
+
     const fromFormatted = moment(from, 'MM/DD/YYYY').format('MM/DD/YYYY');
     const toFormatted = moment(to, 'MM/DD/YYYY').format('MM/DD/YYYY');
     const dateRange = `${fromFormatted} - ${toFormatted}`;

--- a/server/lib/presto/api_endpoints.js
+++ b/server/lib/presto/api_endpoints.js
@@ -1,13 +1,14 @@
 module.exports = {
-  baseUrl: 'https://www.prestocard.ca',
-  loginEndpoint: '/api/sitecore/AFMSAuthentication/SignInWithAccount',
-  logoutEndpoint: '/api/sitecore/AFMSAuthentication/Logout',
-  dashboard: '/en/dashboard',
-  homepage: '/en/',
-  activityEndpoint: '/api/sitecore/Paginator/CardActivityFilteredIndex',
-  switchCards: '/api/sitecore/Global/UpdateFareMediaSession?id=lowerFareMediaId&class=lowerFareMediaId',
-  cardActivity: '/en/dashboard/card-activity',
-  usageReport: '/en/dashboard/transit-usage-report',
-  csvEndpoint: '/api/sitecore/Paginator/TransitUsageExportCSV',
-  usageEndpoint: '/api/sitecore/Paginator/TransitUsageReportFilteredIndex'
+  baseUrl: 'https://www.prestocard.ca/',
+  loginEndpoint: 'api/sitecore/AFMSAuthentication/SignInWithAccount',
+  logoutEndpoint: 'api/sitecore/AFMSAuthentication/Logout',
+  dashboard: 'en/dashboard',
+  homepage: 'en/',
+  activityEndpoint: 'api/sitecore/Paginator/CardActivityFilteredIndex',
+  switchCards:
+    'api/sitecore/Global/UpdateFareMediaSession?id=lowerFareMediaId&class=lowerFareMediaId',
+  cardActivity: 'en/dashboard/card-activity',
+  usageReport: 'en/dashboard/transit-usage-report',
+  csvEndpoint: 'api/sitecore/Paginator/TransitUsageExportCSV',
+  usageEndpoint: 'api/sitecore/Paginator/TransitUsageReportFilteredIndex'
 };

--- a/server/lib/presto/api_wrapper.js
+++ b/server/lib/presto/api_wrapper.js
@@ -1,14 +1,21 @@
-const { login, isLoggedIn } = require('./auth');
-const { getBasicAccountInfo, getUsageReport, getActivityByMonth, getActivityByDateRange } = require('./activity');
+const { login, isLoggedIn, createCookieJar } = require('./auth');
+const {
+  getBasicAccountInfo,
+  getUsageReport,
+  getActivityByMonth,
+  getActivityByDateRange
+} = require('./activity');
 
 module.exports = requestInstance => ({
   // auth.js functions
-  login: (username, password) => login(requestInstance, username, password),
-  isLoggedIn: () => isLoggedIn(requestInstance),
+  login: (username, password, jar) => login(requestInstance, username, password, jar),
+  isLoggedIn: jar => isLoggedIn(requestInstance, jar),
+  createCookieJar: () => createCookieJar(requestInstance),
 
   // activity.js functions
-  getBasicAccountInfo: () => getBasicAccountInfo(requestInstance),
-  getUsageReport: year => getUsageReport(requestInstance, year),
+  getBasicAccountInfo: jar => getBasicAccountInfo(requestInstance, jar),
+  getUsageReport: (year, jar) => getUsageReport(requestInstance, year, jar),
   // getActivityByMonth: (year, month) => getActivityByMonth(requestInstance, year, month),
-  getActivityByDateRange: (from, to, cardNumber) => getActivityByDateRange(requestInstance, from, to, cardNumber)
+  getActivityByDateRange: (from, to, cardNumber, jar) =>
+    getActivityByDateRange(requestInstance, from, to, cardNumber, jar)
 });

--- a/server/lib/presto/api_wrapper.js
+++ b/server/lib/presto/api_wrapper.js
@@ -8,14 +8,14 @@ const {
 
 module.exports = requestInstance => ({
   // auth.js functions
-  login: (username, password, jar) => login(requestInstance, username, password, jar),
-  isLoggedIn: jar => isLoggedIn(requestInstance, jar),
+  login: (username, password) => login(requestInstance, username, password),
+  isLoggedIn: () => isLoggedIn(requestInstance),
   createCookieJar: () => createCookieJar(requestInstance),
 
   // activity.js functions
-  getBasicAccountInfo: jar => getBasicAccountInfo(requestInstance, jar),
+  getBasicAccountInfo: () => getBasicAccountInfo(requestInstance),
   getUsageReport: (year, jar) => getUsageReport(requestInstance, year, jar),
   // getActivityByMonth: (year, month) => getActivityByMonth(requestInstance, year, month),
-  getActivityByDateRange: (from, to, cardNumber, jar) =>
-    getActivityByDateRange(requestInstance, from, to, cardNumber, jar)
+  getActivityByDateRange: (from, to, cardNumber) =>
+    getActivityByDateRange(requestInstance, from, to, cardNumber)
 });

--- a/server/lib/presto/api_wrapper.js
+++ b/server/lib/presto/api_wrapper.js
@@ -3,19 +3,34 @@ const {
   getBasicAccountInfo,
   getUsageReport,
   getActivityByMonth,
+  setCookieJar,
   getActivityByDateRange
 } = require('./activity');
 
-module.exports = requestInstance => ({
+module.exports = requestWrapper => ({
   // auth.js functions
-  login: (username, password) => login(requestInstance, username, password),
-  isLoggedIn: () => isLoggedIn(requestInstance),
-  createCookieJar: () => createCookieJar(requestInstance),
+  login(username, password) {
+    return login.call(this, requestWrapper, username, password);
+  },
+  isLoggedIn() {
+    return isLoggedIn.call(this, requestWrapper);
+  },
+  createCookieJar() {
+    return createCookieJar.call(this, requestWrapper);
+  },
+  setCookieJar(cookies) {
+    return setCookieJar.call(this, requestWrapper, cookies);
+  },
 
   // activity.js functions
-  getBasicAccountInfo: () => getBasicAccountInfo(requestInstance),
-  getUsageReport: (year, jar) => getUsageReport(requestInstance, year, jar),
-  // getActivityByMonth: (year, month) => getActivityByMonth(requestInstance, year, month),
-  getActivityByDateRange: (from, to, cardNumber) =>
-    getActivityByDateRange(requestInstance, from, to, cardNumber)
+  getBasicAccountInfo() {
+    return getBasicAccountInfo.call(this, requestWrapper);
+  },
+  getUsageReport(year, jar) {
+    return getUsageReport.call(this, requestWrapper, year, jar);
+  },
+  // getActivityByMonth: (year, month) => getActivityByMonth(requestWrapper, year, month),
+  getActivityByDateRange(from, to, cardNumber) {
+    return getActivityByDateRange.call(this, requestWrapper, from, to, cardNumber);
+  }
 });

--- a/server/lib/presto/auth.js
+++ b/server/lib/presto/auth.js
@@ -14,7 +14,6 @@ function isSuccessfulLogin(requestBody) {
 
 async function getCSRF(requestInstance, jar, endpoint = API.homepage, parent = '#signwithaccount') {
   const cj = jar;
-  console.log('getCSRF jar:', cj);
   try {
     const { body } = await requestInstance({ uri: endpoint, jar: cj });
     const dom = new JSDOM(body);

--- a/server/lib/presto/auth.js
+++ b/server/lib/presto/auth.js
@@ -12,9 +12,15 @@ function isSuccessfulLogin(requestBody) {
   );
 }
 
-async function getCSRF(requestInstance, endpoint = API.homepage, parent = '#signwithaccount') {
+const getCSRF = async (
+  requestInstance,
+  cookieJar,
+  endpoint = API.homepage,
+  parent = '#signwithaccount'
+) => {
   try {
-    const { body } = await requestInstance({ uri: endpoint, jar: this.cookieJar });
+    console.log('csrf:', cookieJar);
+    const { body } = await requestInstance({ uri: endpoint, jar: cookieJar });
     const dom = new JSDOM(body);
     const token = dom.window.document.querySelector(
       `${parent} input[name='__RequestVerificationToken']`
@@ -30,10 +36,10 @@ async function getCSRF(requestInstance, endpoint = API.homepage, parent = '#sign
     console.log(error);
     return { error };
   }
-}
+};
 
 async function login(requestInstance, username, password) {
-  const CSRFResponse = await getCSRF(requestInstance);
+  const CSRFResponse = await getCSRF(requestInstance, this.cookieJar);
 
   if (typeof CSRFResponse.token !== 'string') {
     return {
@@ -68,7 +74,7 @@ async function login(requestInstance, username, password) {
 
   if (isSuccessfulLogin(loginResponse.body)) {
     console.log('cookieJar:', this.cookieJar);
-    console.log('login Cookies:', this.getCookieJar());
+    console.log('login Cookies:', this.getCookies());
     return { success: true };
   }
 

--- a/server/lib/presto/auth.js
+++ b/server/lib/presto/auth.js
@@ -20,7 +20,12 @@ async function getCSRF(requestInstance, jar, endpoint = API.homepage, parent = '
     const token = dom.window.document.querySelector(
       `${parent} input[name='__RequestVerificationToken']`
     );
-    console.log('cookieJar at getCSRF:', cj);
+    if (!token) {
+      throw new Error(
+        'Could not get token. Session may have expired or user was not logged in correctly.'
+      );
+    }
+
     return { token: token.value, cookies: cj.getCookies(API.baseUrl) };
   } catch (error) {
     console.log(error);

--- a/server/lib/presto/index.js
+++ b/server/lib/presto/index.js
@@ -5,9 +5,17 @@ const req = require('request');
 const apiRequestWrapper = require('./api_wrapper');
 const API = require('./api_endpoints');
 
-const jar = req.jar();
-
 const options = { baseUrl: API.baseUrl };
 const request = promisify(req.defaults(options));
 
-module.exports = apiRequestWrapper(request);
+function Presto(cookieJar) {
+  this.cookieJar = cookieJar || apiRequestWrapper(request).createCookieJar();
+}
+
+Presto.prototype = {
+  ...apiRequestWrapper.call(Presto, request),
+  getCookieJar: () => this.cookieJar.getCookies(API.baseUrl)
+};
+
+console.log(Presto.prototype);
+module.exports = Presto;

--- a/server/lib/presto/index.js
+++ b/server/lib/presto/index.js
@@ -7,7 +7,7 @@ const API = require('./api_endpoints');
 
 const jar = req.jar();
 
-const options = { jar, baseUrl: API.baseUrl };
+const options = { baseUrl: API.baseUrl };
 const request = promisify(req.defaults(options));
 
 module.exports = apiRequestWrapper(request);

--- a/server/lib/presto/index.js
+++ b/server/lib/presto/index.js
@@ -8,14 +8,16 @@ const API = require('./api_endpoints');
 const options = { baseUrl: API.baseUrl };
 const request = promisify(req.defaults(options));
 
-function Presto(cookieJar) {
-  this.cookieJar = cookieJar || apiRequestWrapper(request).createCookieJar();
+function Presto(cookies) {
+  this.cookieJar = request.jar();
+  this.setCookieJar(cookies);
 }
 
 Presto.prototype = {
-  ...apiRequestWrapper.call(Presto, request),
-  getCookieJar: () => this.cookieJar.getCookies(API.baseUrl)
+  ...apiRequestWrapper(request),
+  getCookies() {
+    return this.cookieJar.getCookies(API.baseUrl);
+  }
 };
 
-console.log(Presto.prototype);
 module.exports = Presto;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -510,6 +510,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.0",
         "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -1630,6 +1631,535 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2652,6 +3182,13 @@
       "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -510,7 +510,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.0",
         "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -1631,535 +1630,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2476,6 +1946,11 @@
         }
       }
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
@@ -2760,9 +2235,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2771,9 +2246,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3177,13 +2652,6 @@
       "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3942,6 +3410,22 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "request-promise-core": {
@@ -4682,19 +4166,13 @@
       }
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {

--- a/server/package.json
+++ b/server/package.json
@@ -34,13 +34,14 @@
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.1",
     "jsdom": "^13.1.0",
     "jsonwebtoken": "^8.4.0",
     "moment": "^2.23.0",
     "pg": "^7.7.1",
     "pg-hstore": "^2.3.2",
     "request": "^2.88.0",
-    "sequelize": "^4.42.0"
+    "sequelize": "^4.42.0",
+    "tough-cookie": "^3.0.1"
   }
 }

--- a/server/src/db/models/user.js
+++ b/server/src/db/models/user.js
@@ -1,4 +1,5 @@
 const bcrypt = require('bcryptjs');
+const tough = require('tough-cookie');
 
 module.exports = (sequelize, DataTypes) => {
   // const permissions = DataTypes.ENUM('ADMIN', 'USER');
@@ -38,6 +39,16 @@ module.exports = (sequelize, DataTypes) => {
     },
     permission: {
       type: DataTypes.ARRAY(DataTypes.TEXT)
+    },
+    cookies: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      // get() {
+      //   return tough.toJSON(this.getDataValue('cookies'));
+      // },
+      set(cookies) {
+        this.setDataValue('cookies', JSON.stringify(cookies));
+      }
     }
   });
 

--- a/server/src/routes/presto.js
+++ b/server/src/routes/presto.js
@@ -50,7 +50,8 @@ const routes = (Transaction, User) => {
   });
 
   router.get('/check-login', async (req, res, next) => {
-    const response = await isLoggedIn();
+    const presto = new Presto();
+    const response = await presto.isLoggedIn();
     console.log(response);
 
     if (response === 'true') {

--- a/server/src/routes/presto.js
+++ b/server/src/routes/presto.js
@@ -21,7 +21,7 @@ const routes = (Transaction, User) => {
     }
 
     const presto = new Presto();
-    console.log(presto);
+    console.log(presto, Presto.prototype);
     const prestoLoginResp = await presto.login(
       prestoCredentials.username,
       prestoCredentials.password
@@ -39,7 +39,7 @@ const routes = (Transaction, User) => {
     // check this and save, because they may have added a new card since the last time.
     // could add logic to only do this save if the accountInfo differs from last save,
     // but I don't see the point in going that far as yet.
-    user.cookies = prestoLoginResp.cookieJar;
+    user.cookies = presto.getCookies();
     user.cards = accountInfo;
     user.save();
 
@@ -77,6 +77,8 @@ const routes = (Transaction, User) => {
         attributes: ['cookies']
       });
 
+      const presto = new Presto(userCookies.cookies);
+
       for (let i = 0; i < cards.length; i++) {
         const cardNumber = cards[i];
 
@@ -100,7 +102,7 @@ const routes = (Transaction, User) => {
         }
 
         console.log('/usage cookies:', userCookies.cookies);
-        const usage = await getActivityByDateRange(from, to, cardNumber, userCookies.cookies);
+        const usage = await presto.getActivityByDateRange(from, to, cardNumber);
         console.log(usage);
         if (usage.status === 'error') {
           throw new Error(usage.message);

--- a/server/src/routes/presto.js
+++ b/server/src/routes/presto.js
@@ -72,7 +72,7 @@ const routes = (Transaction, User) => {
       let filterDateString = '';
       let transactions = [];
       const filteredUsage = [];
-      cards = JSON.parse(cards);
+      cards = typeof cards === 'string' ? JSON.parse(cards) : cards;
       if (!req.userId) {
         throw new Error('No user logged in!');
       }

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -4,7 +4,7 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const moment = require('moment');
 
-const { login, getBasicAccountInfo } = require('../../lib/presto');
+const Presto = require('../../lib/presto/api_wrapper');
 const types = require('../../lib/util/types');
 
 const routes = (User, Budget, Transaction, sequelize, Sequelize) => {


### PR DESCRIPTION
Need to remove the global cookie jar, which made it difficult for other users to log in. Generally, so long as the tokens were still active, and the cookie jar was essentially in global memory, everyone would, well, log in and scrape data of the last user to log in, which would then be saved to their accounts. BAD.

Refactoring the presto library to use a cookejar that is specific to the request, with session information that will be saved somewhere (probably locally in a jwt) so that it can be retrieved again for only the user to which the session belongs. The presto library will be able to be instantiated for a single user and initialised with a cookiejar, which it will use for its requests.